### PR TITLE
[BSC] [BASE] [SQUADSWAP] Thanos (v4) integration and volumes

### DIFF
--- a/src/factory/providers/base/squadswap/index.ts
+++ b/src/factory/providers/base/squadswap/index.ts
@@ -2,12 +2,26 @@ import { ITvlParams, ITvlReturn } from '../../../../interfaces/ITvl';
 import formatter from '../../../../util/formatter';
 import uniswapV3 from '../../../../util/calculators/uniswapV3chain';
 import uniswapV2 from '../../../../util/calculators/uniswapV2';
+import thanosVault, {
+  CL_INITIALIZE_TOPIC,
+  BIN_INITIALIZE_TOPIC,
+} from '../../../../util/calculators/thanosVault';
+import BigNumber from 'bignumber.js';
+import CONSTANTS from '../../../../constants/contracts.json';
 
 const V2_START_BLOCK = 19727118;
 const V2_FACTORY_ADDRESS = '0xba34aA640b8Be02A439221BCbea1f48c1035EEF9';
 
 const V3_START_BLOCK = 19730499;
 const V3_FACTORY_ADDRESS = '0xa1288b64F2378276d0Cc56F08397F70BecF7c0EA';
+
+// Thanos (V4)
+const THANOS_START_BLOCK = 40500004;
+const THANOS_VAULT_ADDRESS = '0x126c5d558589788292c33667fba07e07b4b0990b';
+const THANOS_CL_POOL_MANAGER_ADDRESS =
+  '0xbb07a7bdfc50829ce932adccc0498f0e29f49f50';
+const THANOS_BIN_POOL_MANAGER_ADDRESS =
+  '0xd243e0c2fc2a91eace239e0c54023559a47c5f04';
 
 async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
   const { block, chain, provider, web3 } = params;
@@ -36,7 +50,35 @@ async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
     );
   }
 
-  const balances = formatter.sum([balancesV2, balancesV3]);
+  // Thanos (V4) balances, all pool funds are held by a single Vault
+  let balancesThanos = {};
+  if (block >= THANOS_START_BLOCK) {
+    balancesThanos = await thanosVault.getTvl(
+      THANOS_VAULT_ADDRESS,
+      [
+        { address: THANOS_CL_POOL_MANAGER_ADDRESS, topic: CL_INITIALIZE_TOPIC },
+        {
+          address: THANOS_BIN_POOL_MANAGER_ADDRESS,
+          topic: BIN_INITIALIZE_TOPIC,
+        },
+      ],
+      THANOS_START_BLOCK,
+      block,
+      chain,
+      provider,
+      web3,
+    );
+
+    // Thanos pools use the zero address for the native token
+    const ethBalance = await web3.eth.getBalance(THANOS_VAULT_ADDRESS, block);
+    balancesThanos[CONSTANTS.WMAIN_ADDRESS.base] = BigNumber(
+      balancesThanos[CONSTANTS.WMAIN_ADDRESS.base] || 0,
+    )
+      .plus(ethBalance)
+      .toFixed();
+  }
+
+  const balances = formatter.sum([balancesV2, balancesV3, balancesThanos]);
 
   return { balances };
 }

--- a/src/factory/providers/base/squadswap/index.ts
+++ b/src/factory/providers/base/squadswap/index.ts
@@ -2,12 +2,16 @@ import { ITvlParams, ITvlReturn } from '../../../../interfaces/ITvl';
 import formatter from '../../../../util/formatter';
 import uniswapV3 from '../../../../util/calculators/uniswapV3chain';
 import uniswapV2 from '../../../../util/calculators/uniswapV2';
+import squadswapVolumes from '../../../../util/calculators/squadswapVolumes';
 import thanosVault, {
   CL_INITIALIZE_TOPIC,
   BIN_INITIALIZE_TOPIC,
 } from '../../../../util/calculators/thanosVault';
 import BigNumber from 'bignumber.js';
 import CONSTANTS from '../../../../constants/contracts.json';
+
+const THE_GRAPH_API_KEY = process.env?.THE_GRAPH_API_KEY;
+const QUERY_SIZE = 1000;
 
 const V2_START_BLOCK = 19727118;
 const V2_FACTORY_ADDRESS = '0xba34aA640b8Be02A439221BCbea1f48c1035EEF9';
@@ -22,6 +26,12 @@ const THANOS_CL_POOL_MANAGER_ADDRESS =
   '0xbb07a7bdfc50829ce932adccc0498f0e29f49f50';
 const THANOS_BIN_POOL_MANAGER_ADDRESS =
   '0xd243e0c2fc2a91eace239e0c54023559a47c5f04';
+const THANOS_SUBGRAPH_ENDPOINT =
+  'https://api.subgraph.ormilabs.com/api/public/46e5cb0d-fad2-4ba7-8fa5-9bd207380e15/subgraphs/squadswap-thns-v2-base/thns-base/gn';
+
+// Dynamo and WOW are only served by subgraphs, they are used for volumes
+const DYNAMO_SUBGRAPH_ENDPOINT = `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/42unCN8Y1j3RnvqQ8ZNKr91g3V9Msju2sd7pVgWcH8F2`;
+const WOW_SUBGRAPH_ENDPOINT = `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/29yKNuQstCzNDNcnPgFCw27xsThidsNW4kxxo93msXWi`;
 
 async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
   const { block, chain, provider, web3 } = params;
@@ -83,4 +93,81 @@ async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
   return { balances };
 }
 
-export { tvl };
+/**
+ * Volumes are served by a separate subgraph per version, so each of them is
+ * queried and the results are merged. Pool ids never overlap between versions,
+ * while token volumes of the same token are summed up.
+ */
+async function getPoolVolumes(params) {
+  const { pools, block } = params;
+
+  const [dynamoVolumes, wowVolumes, thanosVolumes] = await Promise.all([
+    uniswapV2.getPoolVolumes(
+      DYNAMO_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+      null,
+    ),
+    squadswapVolumes.getV3PoolVolumes(
+      WOW_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+    ),
+    squadswapVolumes.getThanosPoolVolumes(
+      THANOS_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+    ),
+  ]);
+
+  return { ...dynamoVolumes, ...wowVolumes, ...thanosVolumes };
+}
+
+async function getTokenVolumes(params) {
+  const { tokens, block } = params;
+
+  const [dynamoVolumes, wowVolumes, thanosVolumes] = await Promise.all([
+    uniswapV2.getTokenVolumes(
+      DYNAMO_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+      {
+        volume: 'tradeVolume',
+        volumeUsd: 'tradeVolumeUSD',
+      },
+    ),
+    squadswapVolumes.getTokenVolumes(
+      WOW_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+    ),
+    squadswapVolumes.getTokenVolumes(
+      THANOS_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+    ),
+  ]);
+
+  const tokenVolumes = {};
+  for (const versionVolumes of [dynamoVolumes, wowVolumes, thanosVolumes]) {
+    for (const [token, tokenVolume] of Object.entries(versionVolumes)) {
+      if (!tokenVolumes[token]) {
+        tokenVolumes[token] = { volume: BigNumber(0), volumeUsd: BigNumber(0) };
+      }
+      tokenVolumes[token] = {
+        volume: tokenVolumes[token].volume.plus(tokenVolume.volume),
+        volumeUsd: tokenVolumes[token].volumeUsd.plus(tokenVolume.volumeUsd),
+      };
+    }
+  }
+
+  return tokenVolumes;
+}
+
+export { tvl, getPoolVolumes, getTokenVolumes };

--- a/src/factory/providers/bsc/squadswap/index.ts
+++ b/src/factory/providers/bsc/squadswap/index.ts
@@ -1,8 +1,13 @@
 import { ITvlParams, ITvlReturn } from '../../../../interfaces/ITvl';
 import formatter from '../../../../util/formatter';
 import uniswapV3 from '../../../../util/calculators/uniswapV3chain';
+import thanosVault, {
+  CL_INITIALIZE_TOPIC,
+  BIN_INITIALIZE_TOPIC,
+} from '../../../../util/calculators/thanosVault';
 import BigNumber from 'bignumber.js';
 import { request, gql } from 'graphql-request';
+import CONSTANTS from '../../../../constants/contracts.json';
 
 // Constants for original versions
 const V2_START_BLOCK = 34130751;
@@ -15,6 +20,14 @@ const DYNAMO_START_BLOCK = 46188894;
 const WOW_START_BLOCK = 46190543;
 const WOW_FACTORY_ADDRESS = '0x10d8612D9D8269e322AB551C18a307cB4D6BC07B';
 const DYNAMO_SUBGRAPH_ENDPOINT = `https://api.studio.thegraph.com/query/76181/exchangev2-wd/version/latest`;
+
+// Constants for Thanos (V4)
+const THANOS_START_BLOCK = 74380131;
+const THANOS_VAULT_ADDRESS = '0x3754bd79d88e89f397ed1bffad8cdf3e0fdcc37e';
+const THANOS_CL_POOL_MANAGER_ADDRESS =
+  '0x9d3b119eff69cd81d324f654062b6ffa3dd7f405';
+const THANOS_BIN_POOL_MANAGER_ADDRESS =
+  '0xd7a5a9df1719ee83a4d10749019caabf137debac';
 
 const QUERY_SIZE = 1000;
 const TOKENS = gql`
@@ -103,12 +116,41 @@ async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
     );
   }
 
+  // Thanos (V4) balances, all pool funds are held by a single Vault
+  let balancesThanos = {};
+  if (block >= THANOS_START_BLOCK) {
+    balancesThanos = await thanosVault.getTvl(
+      THANOS_VAULT_ADDRESS,
+      [
+        { address: THANOS_CL_POOL_MANAGER_ADDRESS, topic: CL_INITIALIZE_TOPIC },
+        {
+          address: THANOS_BIN_POOL_MANAGER_ADDRESS,
+          topic: BIN_INITIALIZE_TOPIC,
+        },
+      ],
+      THANOS_START_BLOCK,
+      block,
+      chain,
+      provider,
+      web3,
+    );
+
+    // Thanos pools use the zero address for the native token
+    const bnbBalance = await web3.eth.getBalance(THANOS_VAULT_ADDRESS, block);
+    balancesThanos[CONSTANTS.WMAIN_ADDRESS.bsc] = BigNumber(
+      balancesThanos[CONSTANTS.WMAIN_ADDRESS.bsc] || 0,
+    )
+      .plus(bnbBalance)
+      .toFixed();
+  }
+
   // Combine all balances
   const balances = formatter.sum([
     balancesV2,
     balancesV3,
     balancesDynamo,
     balancesWow,
+    balancesThanos,
   ]);
 
   return { balances };

--- a/src/factory/providers/bsc/squadswap/index.ts
+++ b/src/factory/providers/bsc/squadswap/index.ts
@@ -1,6 +1,8 @@
 import { ITvlParams, ITvlReturn } from '../../../../interfaces/ITvl';
 import formatter from '../../../../util/formatter';
 import uniswapV3 from '../../../../util/calculators/uniswapV3chain';
+import uniswapV2Subgraph from '../../../../util/calculators/uniswapV2';
+import squadswapVolumes from '../../../../util/calculators/squadswapVolumes';
 import thanosVault, {
   CL_INITIALIZE_TOPIC,
   BIN_INITIALIZE_TOPIC,
@@ -8,6 +10,8 @@ import thanosVault, {
 import BigNumber from 'bignumber.js';
 import { request, gql } from 'graphql-request';
 import CONSTANTS from '../../../../constants/contracts.json';
+
+const THE_GRAPH_API_KEY = process.env?.THE_GRAPH_API_KEY;
 
 // Constants for original versions
 const V2_START_BLOCK = 34130751;
@@ -19,7 +23,8 @@ const V2_SUBGRAPH_ENDPOINT = `https://api.studio.thegraph.com/query/76181/exchan
 const DYNAMO_START_BLOCK = 46188894;
 const WOW_START_BLOCK = 46190543;
 const WOW_FACTORY_ADDRESS = '0x10d8612D9D8269e322AB551C18a307cB4D6BC07B';
-const DYNAMO_SUBGRAPH_ENDPOINT = `https://api.studio.thegraph.com/query/76181/exchangev2-wd/version/latest`;
+const DYNAMO_SUBGRAPH_ENDPOINT = `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/C9FE68cq1GXDiR1qghTQRaH5wVs5S5y4qwqd7cSEZ3Ur`;
+const WOW_SUBGRAPH_ENDPOINT = `https://gateway.thegraph.com/api/${THE_GRAPH_API_KEY}/subgraphs/id/BgxeY5c3MiwAt4ahqiSq13eKWMGz9ax7dCgwxE7T7Nyn`;
 
 // Constants for Thanos (V4)
 const THANOS_START_BLOCK = 74380131;
@@ -28,6 +33,8 @@ const THANOS_CL_POOL_MANAGER_ADDRESS =
   '0x9d3b119eff69cd81d324f654062b6ffa3dd7f405';
 const THANOS_BIN_POOL_MANAGER_ADDRESS =
   '0xd7a5a9df1719ee83a4d10749019caabf137debac';
+const THANOS_SUBGRAPH_ENDPOINT =
+  'https://api.subgraph.ormilabs.com/api/public/46e5cb0d-fad2-4ba7-8fa5-9bd207380e15/subgraphs/squadswap-thns-v2-bsc/thns-bsc/gn';
 
 const QUERY_SIZE = 1000;
 const TOKENS = gql`
@@ -156,4 +163,81 @@ async function tvl(params: ITvlParams): Promise<Partial<ITvlReturn>> {
   return { balances };
 }
 
-export { tvl };
+/**
+ * Volumes are served by a separate subgraph per version, so each of them is
+ * queried and the results are merged. Pool ids never overlap between versions,
+ * while token volumes of the same token are summed up.
+ */
+async function getPoolVolumes(params) {
+  const { pools, block } = params;
+
+  const [dynamoVolumes, wowVolumes, thanosVolumes] = await Promise.all([
+    uniswapV2Subgraph.getPoolVolumes(
+      DYNAMO_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+      null,
+    ),
+    squadswapVolumes.getV3PoolVolumes(
+      WOW_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+    ),
+    squadswapVolumes.getThanosPoolVolumes(
+      THANOS_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      pools,
+      block,
+    ),
+  ]);
+
+  return { ...dynamoVolumes, ...wowVolumes, ...thanosVolumes };
+}
+
+async function getTokenVolumes(params) {
+  const { tokens, block } = params;
+
+  const [dynamoVolumes, wowVolumes, thanosVolumes] = await Promise.all([
+    uniswapV2Subgraph.getTokenVolumes(
+      DYNAMO_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+      {
+        volume: 'tradeVolume',
+        volumeUsd: 'tradeVolumeUSD',
+      },
+    ),
+    squadswapVolumes.getTokenVolumes(
+      WOW_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+    ),
+    squadswapVolumes.getTokenVolumes(
+      THANOS_SUBGRAPH_ENDPOINT,
+      QUERY_SIZE,
+      tokens,
+      block,
+    ),
+  ]);
+
+  const tokenVolumes = {};
+  for (const versionVolumes of [dynamoVolumes, wowVolumes, thanosVolumes]) {
+    for (const [token, tokenVolume] of Object.entries(versionVolumes)) {
+      if (!tokenVolumes[token]) {
+        tokenVolumes[token] = { volume: BigNumber(0), volumeUsd: BigNumber(0) };
+      }
+      tokenVolumes[token] = {
+        volume: tokenVolumes[token].volume.plus(tokenVolume.volume),
+        volumeUsd: tokenVolumes[token].volumeUsd.plus(tokenVolume.volumeUsd),
+      };
+    }
+  }
+
+  return tokenVolumes;
+}
+
+export { tvl, getPoolVolumes, getTokenVolumes };

--- a/src/util/calculators/squadswapVolumes.ts
+++ b/src/util/calculators/squadswapVolumes.ts
@@ -1,0 +1,265 @@
+import BigNumber from 'bignumber.js';
+import { gql, request } from 'graphql-request';
+import { log } from '../logger/logger';
+
+/**
+ * SquadSwap serves every version from its own subgraph, so volumes have to be
+ * collected per version and merged by the provider.
+ *
+ * The uniswapV2 calculator already covers the v2 schema (dynamo), these
+ * functions cover the two schemas it does not: the v3 one (wow) and thanos,
+ * which keeps its pools on two separate pool managers.
+ */
+
+const V3_POOL_VOLUMES_QUERY = (querySize: number, block = null) => gql`
+  query getPoolVolumes($pools: [ID!]) {
+    pools(
+      where: { id_in: $pools },
+      ${block ? `block: {number: ${block}},` : ''}
+      first: ${querySize}
+    ) {
+      id
+      token0 {
+        decimals
+      }
+      token1 {
+        decimals
+      }
+      volumeToken0
+      volumeToken1
+      volumeUSD
+    }
+  }
+`;
+
+const THANOS_POOL_VOLUMES_QUERY = (querySize: number, block = null) => gql`
+  query getPoolVolumes($pools: [ID!]) {
+    clpools(
+      where: { id_in: $pools },
+      ${block ? `block: {number: ${block}},` : ''}
+      first: ${querySize}
+    ) {
+      id
+      token0 {
+        decimals
+      }
+      token1 {
+        decimals
+      }
+      volumeToken0
+      volumeToken1
+      volumeUSD
+    }
+    binPools(
+      where: { id_in: $pools },
+      ${block ? `block: {number: ${block}},` : ''}
+      first: ${querySize}
+    ) {
+      id
+      token0 {
+        decimals
+      }
+      token1 {
+        decimals
+      }
+      volumeToken0
+      volumeToken1
+      volumeUSD
+    }
+  }
+`;
+
+const TOKEN_VOLUMES_QUERY = (querySize: number, block = null) => gql`
+  query getTokenVolumes($tokens: [ID!]) {
+    tokens(
+      where: { id_in: $tokens },
+      ${block ? `block: {number: ${block}},` : ''}
+      first: ${querySize}
+    ) {
+      id
+      decimals
+      volume
+      volumeUSD
+    }
+  }
+`;
+
+interface IPoolVolumes {
+  [key: string]: {
+    volumes: string[];
+    volumeUsd: string;
+  };
+}
+
+interface ITokenVolumes {
+  [key: string]: {
+    volume: string;
+    volumeUsd: string;
+  };
+}
+
+function sumPoolVolumes(
+  poolVolumes: IPoolVolumes,
+  currentPools,
+  priorPools,
+): void {
+  currentPools.forEach((pool) => {
+    poolVolumes[pool.id] = {
+      volumes: [BigNumber(pool.volumeToken0), BigNumber(pool.volumeToken1)],
+      volumeUsd: BigNumber(pool.volumeUSD),
+    };
+  });
+  priorPools.forEach((pool) => {
+    if (!poolVolumes[pool.id]) {
+      return;
+    }
+    poolVolumes[pool.id] = {
+      volumes: [
+        poolVolumes[pool.id].volumes[0]
+          .minus(pool.volumeToken0)
+          .times(10 ** (pool.token0.decimals || 0)),
+        poolVolumes[pool.id].volumes[1]
+          .minus(pool.volumeToken1)
+          .times(10 ** (pool.token1.decimals || 0)),
+      ],
+      volumeUsd: poolVolumes[pool.id].volumeUsd.minus(pool.volumeUSD),
+    };
+  });
+}
+
+async function getPoolVolumes(
+  queryApi: string,
+  querySize: number,
+  pools: string[],
+  priorBlockNumber: number,
+  query: (querySize: number, block?: number) => string,
+  pickPools: (response) => unknown[],
+): Promise<IPoolVolumes> {
+  const poolVolumes = {};
+
+  for (let i = 0; i < pools?.length || 0; i += querySize) {
+    const requestedPools = pools.slice(i, i + querySize);
+    try {
+      const currentPools = await request(queryApi, query(querySize), {
+        pools: requestedPools,
+      }).then(pickPools);
+      const priorPools = await request(
+        queryApi,
+        query(querySize, priorBlockNumber),
+        { pools: requestedPools },
+      ).then(pickPools);
+
+      sumPoolVolumes(poolVolumes, currentPools, priorPools);
+    } catch (e) {
+      log.warning({
+        message: e?.message || '',
+        stack: e?.stack || '',
+        detail: `Error: getPoolVolumes`,
+        endpoint: 'getPoolVolumes',
+      });
+    }
+  }
+
+  return poolVolumes;
+}
+
+/**
+ * Gets pool volumes of a Uniswap V3 like SquadSwap version (wow)
+ */
+async function getV3PoolVolumes(
+  queryApi: string,
+  querySize: number,
+  pools: string[],
+  priorBlockNumber: number,
+): Promise<IPoolVolumes> {
+  return getPoolVolumes(
+    queryApi,
+    querySize,
+    pools,
+    priorBlockNumber,
+    V3_POOL_VOLUMES_QUERY,
+    (response) => response.pools,
+  );
+}
+
+/**
+ * Gets pool volumes of Thanos, whose pools are split between the CL and the
+ * Bin pool manager
+ */
+async function getThanosPoolVolumes(
+  queryApi: string,
+  querySize: number,
+  pools: string[],
+  priorBlockNumber: number,
+): Promise<IPoolVolumes> {
+  return getPoolVolumes(
+    queryApi,
+    querySize,
+    pools,
+    priorBlockNumber,
+    THANOS_POOL_VOLUMES_QUERY,
+    (response) => [...response.clpools, ...response.binPools],
+  );
+}
+
+/**
+ * Gets token volumes of the SquadSwap versions using the `volume` and
+ * `volumeUSD` token fields, which both the v3 and the thanos subgraphs share
+ */
+async function getTokenVolumes(
+  queryApi: string,
+  querySize: number,
+  tokens: string[],
+  priorBlockNumber: number,
+): Promise<ITokenVolumes> {
+  const tokenVolumes = {};
+
+  for (let i = 0; i < tokens?.length || 0; i += querySize) {
+    const requestedTokens = tokens.slice(i, i + querySize);
+    try {
+      const currentTokens = await request(
+        queryApi,
+        TOKEN_VOLUMES_QUERY(querySize),
+        { tokens: requestedTokens },
+      ).then((response) => response.tokens);
+      const priorTokens = await request(
+        queryApi,
+        TOKEN_VOLUMES_QUERY(querySize, priorBlockNumber),
+        { tokens: requestedTokens },
+      ).then((response) => response.tokens);
+
+      currentTokens.forEach((token) => {
+        tokenVolumes[token.id] = {
+          volume: BigNumber(token.volume),
+          volumeUsd: BigNumber(token.volumeUSD),
+        };
+      });
+      priorTokens.forEach((token) => {
+        if (!tokenVolumes[token.id]) {
+          return;
+        }
+        tokenVolumes[token.id] = {
+          volume: tokenVolumes[token.id].volume
+            .minus(token.volume)
+            .times(10 ** (token.decimals || 0)),
+          volumeUsd: tokenVolumes[token.id].volumeUsd.minus(token.volumeUSD),
+        };
+      });
+    } catch (e) {
+      log.warning({
+        message: e?.message || '',
+        stack: e?.stack || '',
+        detail: `Error: getTokenVolumes`,
+        endpoint: 'getTokenVolumes',
+      });
+    }
+  }
+
+  return tokenVolumes;
+}
+
+export default {
+  getV3PoolVolumes,
+  getThanosPoolVolumes,
+  getTokenVolumes,
+};

--- a/src/util/calculators/thanosVault.ts
+++ b/src/util/calculators/thanosVault.ts
@@ -1,0 +1,155 @@
+import formatter from '../formatter';
+import basicUtil from '../basicUtil';
+import util from '../blockchainUtil';
+import { log } from '../logger/logger';
+import { IBalances } from '../../interfaces/ITvl';
+import Web3 from 'web3';
+
+/**
+ * SquadSwap Thanos (v4) keeps every pool's funds in a single Vault, while pools
+ * themselves are created on separate CL and Bin pool managers.
+ * Tokens are collected from the Initialize events of each pool manager and their
+ * balances are then read from the Vault.
+ */
+
+// Initialize(bytes32,address,address,address,uint24,bytes32,uint160,int24)
+export const CL_INITIALIZE_TOPIC =
+  '0x426cc62fe6a33a40ba2788c2c87a9c34ee4582b95bc9fa5a7bb7ae70b750b99c';
+// Initialize(bytes32,address,address,address,uint24,bytes32,uint24)
+export const BIN_INITIALIZE_TOPIC =
+  '0xddfde5903015c0eb1671976c6c8f760f1328bec57f15286b6bdab2f955cab9c9';
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+interface IPoolManager {
+  address: string;
+  topic: string;
+}
+
+async function getTvl(
+  vaultAddress: string,
+  poolManagers: IPoolManager[],
+  startBlock: number,
+  block: number,
+  chain: string,
+  provider: string,
+  web3: Web3,
+): Promise<IBalances> {
+  const balances = {};
+
+  const cache = { block: startBlock, tokens: [] };
+  try {
+    cache.block = await basicUtil.readFromCache(
+      `${vaultAddress}/thanosBlock.json`,
+      chain,
+      provider,
+    );
+    cache.tokens = await basicUtil.readFromCache(
+      `${vaultAddress}/thanosTokens.json`,
+      chain,
+      provider,
+    );
+  } catch {}
+
+  const tokens = cache.tokens;
+
+  let offset = 10000;
+
+  if (Math.max(cache.block, startBlock) < block) {
+    for (let i = Math.max(cache.block, startBlock); ; ) {
+      let eventLogs = [];
+      try {
+        const results = await Promise.all(
+          poolManagers.map((poolManager) =>
+            util.getLogs(
+              i,
+              Math.min(block, i + offset - 1),
+              poolManager.topic,
+              poolManager.address,
+              web3,
+            ),
+          ),
+        );
+        results.forEach((result) => eventLogs.push(...result.output));
+      } catch (e) {
+        log.warning({
+          message: e?.message || '',
+          stack: e?.stack || '',
+          detail: `Error: tvl of ${chain}/${provider}`,
+          endpoint: 'tvl',
+        });
+        if (offset >= 2000) {
+          offset -= 1000;
+        } else if (offset > 300) {
+          offset -= 200;
+        } else if (offset > 30) {
+          offset -= 20;
+        } else {
+          break;
+        }
+        continue;
+      }
+
+      eventLogs.forEach((eventLog) => {
+        const token0 = `0x${eventLog.topics[2].slice(26)}`.toLowerCase();
+        const token1 = `0x${eventLog.topics[3].slice(26)}`.toLowerCase();
+
+        if (!tokens.includes(token0)) tokens.push(token0);
+        if (!tokens.includes(token1)) tokens.push(token1);
+      });
+
+      // Save into cache every 25 iterations
+      if (((i - Math.max(cache.block, startBlock)) / offset) % 25 === 0) {
+        await basicUtil.saveIntoCache(
+          i,
+          `${vaultAddress}/thanosBlock.json`,
+          chain,
+          provider,
+        );
+        await basicUtil.saveIntoCache(
+          tokens,
+          `${vaultAddress}/thanosTokens.json`,
+          chain,
+          provider,
+        );
+      }
+
+      i += offset;
+      if (block < i) {
+        break;
+      }
+    }
+
+    // Save into cache on the last iteration
+    await basicUtil.saveIntoCache(
+      block,
+      `${vaultAddress}/thanosBlock.json`,
+      chain,
+      provider,
+    );
+    await basicUtil.saveIntoCache(
+      tokens,
+      `${vaultAddress}/thanosTokens.json`,
+      chain,
+      provider,
+    );
+  }
+
+  // The native token is stored as the zero address, its balance is added by the provider
+  const tokenBalances = await util.getTokenBalances(
+    vaultAddress,
+    tokens.filter((token) => token !== ZERO_ADDRESS),
+    block,
+    chain,
+    web3,
+  );
+
+  formatter.sumMultiBalanceOf(balances, tokenBalances);
+  formatter.convertBalancesToFixed(balances);
+
+  return balances;
+}
+
+export default {
+  getTvl,
+};


### PR DESCRIPTION
Adds SquadSwap Thanos (v4) TVL and implements pool/token volumes for the
existing `squadswap` providers on BSC and Base.

## Thanos (v4) TVL

Thanos keeps every pool's funds in a single Vault while pools are created on
separate CL and Bin pool managers, so a new calculator
`src/util/calculators/thanosVault.ts` collects the token list from the
`Initialize` events of both pool managers (with block/token caching and the
usual adaptive log-range backoff) and reads the balances from the Vault.

Native token is stored as the zero address in Thanos pools, so the Vault's
native balance is added onto `WMAIN_ADDRESS` in each provider.

Thanos balances are summed alongside the existing v2 / v3 / dynamo / wow
balances and are only fetched from the Thanos start block onwards:

- BSC: vault `0x3754bd79d88e89f397ed1bffad8cdf3e0fdcc37e`, from block 74380131
- Base: vault `0x126c5d558589788292c33667fba07e07b4b0990b`, from block 40500004

## Volumes

`getPoolVolumes` and `getTokenVolumes` are now implemented for both chains.
Each SquadSwap version is served by its own subgraph, so all of them are
queried and the results are merged — pool ids never overlap between versions,
while token volumes of the same token are summed up:

- dynamo (v2 schema) through the existing `uniswapV2` calculator
- wow (v3 schema) and thanos through a new `src/util/calculators/squadswapVolumes.ts`

Thanos keeps its pools on two separate pool managers, so its CL and Bin pools
are queried together and merged into a single result. No existing shared
calculator was modified.

Subgraphs used, all of them published on the decentralized network and queried
through `THE_GRAPH_API_KEY` (thanos is served by Ormi):

| Version | Chain | Subgraph |
| --- | --- | --- |
| dynamo | BSC | `C9FE68cq1GXDiR1qghTQRaH5wVs5S5y4qwqd7cSEZ3Ur` |
| wow | BSC | `BgxeY5c3MiwAt4ahqiSq13eKWMGz9ax7dCgwxE7T7Nyn` |
| dynamo | Base | `42unCN8Y1j3RnvqQ8ZNKr91g3V9Msju2sd7pVgWcH8F2` |
| wow | Base | `29yKNuQstCzNDNcnPgFCw27xsThidsNW4kxxo93msXWi` |

## Dynamo TVL fix

The dynamo TVL endpoint pointed at
`api.studio.thegraph.com/query/76181/exchangev2-wd`, which no longer exists —
the gateway answers with `deployment does not exist`. `fetchTokenBalances` has
no error handling, so every BSC squadswap TVL request above
`DYNAMO_START_BLOCK` (46188894) was failing outright, not just the dynamo part
of it. It now points at the published dynamo subgraph on the gateway.

## Testing

Volumes were verified against the live subgraphs for both chains: all requested
pools were returned (7/7 on BSC, 5/5 on Base) and token volumes are correctly
summed across versions.

No integration test was added in `factory.spec.ts` — verifying the expected TVL
balances requires an archive RPC for BSC and Base, which I don't have access
to. Happy to add one if you can point me at a suitable endpoint.